### PR TITLE
fix: clippy errors on columbus-5 branch

### DIFF
--- a/contracts/terraswap_factory/src/testing.rs
+++ b/contracts/terraswap_factory/src/testing.rs
@@ -197,7 +197,7 @@ fn reply_test() {
             &mut deps.storage,
             &TmpPairInfo {
                 asset_infos: raw_infos,
-                pair_key: pair_key.clone(),
+                pair_key,
             },
         )
         .unwrap();
@@ -227,7 +227,7 @@ fn reply_test() {
         },
     )]);
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     let query_res = query(
         deps.as_ref(),
@@ -244,7 +244,7 @@ fn reply_test() {
         PairInfo {
             liquidity_token: Addr::unchecked("liquidity0000"),
             contract_addr: Addr::unchecked("pair0000"),
-            asset_infos: asset_infos.clone(),
+            asset_infos,
         }
     );
 }

--- a/contracts/terraswap_pair/src/mock_querier.rs
+++ b/contracts/terraswap_pair/src/mock_querier.rs
@@ -154,7 +154,7 @@ impl WasmMockQuerier {
                                 name: "mAAPL".to_string(),
                                 symbol: "mAAPL".to_string(),
                                 decimals: 6,
-                                total_supply: total_supply,
+                                total_supply,
                             })
                             .unwrap(),
                         ))

--- a/contracts/terraswap_pair/src/testing.rs
+++ b/contracts/terraswap_pair/src/testing.rs
@@ -80,7 +80,7 @@ fn proper_initialization() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     // it worked, let's query the state
     let pair_info: PairInfo = query_pair_info(deps.as_ref()).unwrap();
@@ -144,7 +144,7 @@ fn provide_liquidity() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     // successfully provide liquidity for the exist pool
     let msg = ExecuteMsg::ProvideLiquidity {
@@ -541,7 +541,7 @@ fn withdraw_liquidity() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     // withdraw liquidity
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
@@ -663,7 +663,7 @@ fn try_native_to_token() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     // normal swap
     let msg = ExecuteMsg::Swap {
@@ -773,7 +773,7 @@ fn try_native_to_token() {
             contract_addr: "asset0000".to_string(),
             msg: to_binary(&Cw20ExecuteMsg::Transfer {
                 recipient: "addr0000".to_string(),
-                amount: Uint128::from(expected_return_amount),
+                amount: expected_return_amount,
             })
             .unwrap(),
             send: vec![],
@@ -844,7 +844,7 @@ fn try_token_to_native() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     // unauthorized access; can not execute swap directly for token swap
     let msg = ExecuteMsg::Swap {
@@ -1054,7 +1054,7 @@ fn test_deduct() {
         &[(&"uusd".to_string(), &Uint128::from(1000000u128))],
     );
 
-    let amount = Uint128(1000_000_000u128);
+    let amount = Uint128(1_000_000_000u128);
     let expected_after_amount = std::cmp::max(
         amount.checked_sub(amount * tax_rate).unwrap(),
         amount.checked_sub(tax_cap).unwrap(),
@@ -1124,7 +1124,7 @@ fn test_query_pool() {
         }),
     };
 
-    let _res = reply(deps.as_mut(), mock_env(), reply_msg.clone()).unwrap();
+    let _res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
 
     let res: PoolResponse = query_pool(deps.as_ref()).unwrap();
 

--- a/contracts/terraswap_router/src/contract.rs
+++ b/contracts/terraswap_router/src/contract.rs
@@ -355,7 +355,7 @@ fn assert_operations(operations: &[SwapOperation]) -> StdResult<()> {
 #[test]
 fn test_invalid_operations() {
     // empty error
-    assert_eq!(true, assert_operations(&vec![]).is_err());
+    assert_eq!(true, assert_operations(&[]).is_err());
 
     // uluna output
     assert_eq!(

--- a/packages/terraswap/src/mock_querier.rs
+++ b/packages/terraswap/src/mock_querier.rs
@@ -189,7 +189,7 @@ impl WasmMockQuerier {
                                     name: "mAAPL".to_string(),
                                     symbol: "mAAPL".to_string(),
                                     decimals: 6,
-                                    total_supply: total_supply,
+                                    total_supply,
                                 })
                                 .unwrap(),
                             ))


### PR DESCRIPTION
Creating this PR to fix clippy errors on the columbus-5 terraswap 2.x. Doing this since clippy fails on ozone-contracts repo since clippy runs on dependencies as well which includes this.