### PR TITLE
[Proposal] Add optional receiver parameter to ProvideLiquidity msg

### DIFF
--- a/contracts/terraswap_pair/schema/execute_msg.json
+++ b/contracts/terraswap_pair/schema/execute_msg.json
@@ -35,6 +35,12 @@
               "maxItems": 2,
               "minItems": 2
             },
+            "receiver": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "slippage_tolerance": {
               "anyOf": [
                 {

--- a/contracts/terraswap_pair/src/contract.rs
+++ b/contracts/terraswap_pair/src/contract.rs
@@ -86,7 +86,8 @@ pub fn execute(
         ExecuteMsg::ProvideLiquidity {
             assets,
             slippage_tolerance,
-        } => provide_liquidity(deps, env, info, assets, slippage_tolerance),
+            receiver,
+        } => provide_liquidity(deps, env, info, assets, slippage_tolerance, receiver),
         ExecuteMsg::Swap {
             offer_asset,
             belief_price,
@@ -212,6 +213,7 @@ pub fn provide_liquidity(
     info: MessageInfo,
     assets: [Asset; 2],
     slippage_tolerance: Option<Decimal>,
+    receiver: Option<String>,
 ) -> Result<Response, ContractError> {
     for asset in assets.iter() {
         asset.assert_sent_native_token_balance(&info)?;
@@ -280,7 +282,7 @@ pub fn provide_liquidity(
             .addr_humanize(&pair_info.liquidity_token)?
             .to_string(),
         msg: to_binary(&Cw20ExecuteMsg::Mint {
-            recipient: info.sender.to_string(),
+            recipient: receiver.unwrap_or(info.sender.to_string()),
             amount: share,
         })?,
         send: vec![],

--- a/contracts/terraswap_pair/src/testing.rs
+++ b/contracts/terraswap_pair/src/testing.rs
@@ -163,6 +163,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: None,
+        receiver: None,
     };
 
     let env = mock_env();
@@ -239,6 +240,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: None,
+        receiver: Some("staking0000".to_string()), // try changing receiver
     };
 
     let env = mock_env();
@@ -272,7 +274,7 @@ fn provide_liquidity() {
         &CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "liquidity0000".to_string(),
             msg: to_binary(&Cw20ExecuteMsg::Mint {
-                recipient: "addr0000".to_string(),
+                recipient: "staking0000".to_string(), // LP tokens sent to specified receiver
                 amount: Uint128::from(50u128),
             })
             .unwrap(),
@@ -297,6 +299,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: None,
+        receiver: None,
     };
 
     let env = mock_env();
@@ -353,6 +356,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: Some(Decimal::percent(1)),
+        receiver: None,
     };
 
     let env = mock_env();
@@ -395,6 +399,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: Some(Decimal::percent(1)),
+        receiver: None,
     };
 
     let env = mock_env();
@@ -437,6 +442,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: Some(Decimal::percent(1)),
+        receiver: None,
     };
 
     let env = mock_env();
@@ -475,6 +481,7 @@ fn provide_liquidity() {
             },
         ],
         slippage_tolerance: Some(Decimal::percent(1)),
+        receiver: None,
     };
 
     let env = mock_env();

--- a/packages/terraswap/src/pair.rs
+++ b/packages/terraswap/src/pair.rs
@@ -22,6 +22,7 @@ pub enum ExecuteMsg {
     ProvideLiquidity {
         assets: [Asset; 2],
         slippage_tolerance: Option<Decimal>,
+        receiver: Option<String>,
     },
     /// Swap an offer asset to the other
     Swap {


### PR DESCRIPTION
### Problem
Currently, to do auto-staking we need to:
`user transfers both assets to staking -> staking provides liquidity to pair (transfering both assets) -> pair raturns LP tokens to staking`

Usually, one of the assets is UST, which means that we need to pay taxes 2 times.

### Proposed solution
If we add an optional receiver parameter to the `ProvideLiquidity` msg, we can make the AutoStaking logic for Mirror and future projects more easy and efficient.