### PR TITLE
fix: reverse_simulation fn header and clippy

### DIFF
--- a/contracts/terraswap_pair/src/contract.rs
+++ b/contracts/terraswap_pair/src/contract.rs
@@ -283,7 +283,7 @@ pub fn provide_liquidity(
             .addr_humanize(&pair_info.liquidity_token)?
             .to_string(),
         msg: to_binary(&Cw20ExecuteMsg::Mint {
-            recipient: receiver.unwrap_or(info.sender.to_string()),
+            recipient: receiver.unwrap_or_else(|| info.sender.to_string()),
             amount: share,
         })?,
         funds: vec![],
@@ -597,8 +597,8 @@ fn compute_offer_amount(
     ) - offer_pool.into();
 
     let before_commission_deduction: Uint256 = Uint256::from(ask_amount) * inv_one_minus_commission;
-    let before_spread_deduction: Uint256 = Uint256::from(offer_amount)
-        * Decimal256::from_ratio(Uint256::from(ask_pool), Uint256::from(offer_pool));
+    let before_spread_deduction: Uint256 =
+        offer_amount * Decimal256::from_ratio(Uint256::from(ask_pool), Uint256::from(offer_pool));
 
     let spread_amount = if before_spread_deduction > before_commission_deduction {
         before_spread_deduction - before_commission_deduction

--- a/packages/terraswap/src/querier.rs
+++ b/packages/terraswap/src/querier.rs
@@ -3,8 +3,8 @@ use crate::factory::QueryMsg as FactoryQueryMsg;
 use crate::pair::{QueryMsg as PairQueryMsg, ReverseSimulationResponse, SimulationResponse};
 
 use cosmwasm_std::{
-    to_binary, Addr, AllBalanceResponse, Api, BalanceResponse, BankQuery, Coin, Querier,
-    QuerierWrapper, QueryRequest, StdResult, Storage, Uint128, WasmQuery,
+    to_binary, Addr, AllBalanceResponse, BalanceResponse, BankQuery, Coin, QuerierWrapper,
+    QueryRequest, StdResult, Uint128, WasmQuery,
 };
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 
@@ -82,7 +82,7 @@ pub fn simulate(
     }))
 }
 
-pub fn reverse_simulate<S: Storage, A: Api, Q: Querier>(
+pub fn reverse_simulate(
     querier: &QuerierWrapper,
     pair_contract: Addr,
     ask_asset: &Asset,


### PR DESCRIPTION
- baby bug in the terraswap querier reverse_simulate function. Removed the <S: Storage, A: Api, Q: Querier> to be compatible with cosmwasm-std 0.15+ standard.
- found when trying to use the function, interim fix is to use simulate and add return_amount + comission_amount